### PR TITLE
Run migrations automatically on startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from fastapi.security import APIKeyHeader
 from starlette.middleware.cors import CORSMiddleware
 
 from src.api.routers import all_routers
+from src.database.migrations import ensure_schema_is_up_to_date
 
 # ─── Swagger метаданные ───────────────────────────────────────────────
 tags_metadata = [
@@ -36,6 +37,13 @@ app.add_middleware(
 # ─── маршруты ─────────────────────────────────────────────────────────
 for router in all_routers:
     app.include_router(router)
+
+
+@app.on_event("startup")
+async def _run_db_migrations() -> None:
+    """Ensure the database schema is migrated before serving requests."""
+
+    ensure_schema_is_up_to_date()
 
 # ─── примеры cURL прямо в Swagger ─────────────────────────────────────
 def custom_openapi():

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -1,0 +1,47 @@
+"""Utilities for keeping the database schema up to date on application start."""
+
+from __future__ import annotations
+
+import fcntl
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+from src.infra.logger import logger
+
+# The workers started by Gunicorn are different processes.  We guard the
+# migration execution with a file based lock so that only one of them performs
+# the potentially expensive Alembic upgrade.  The other workers will wait for
+# the lock and simply continue once the schema is up to date.
+_LOCK_FILE = Path("/tmp/.alembic_migration.lock")
+_STAMP_FILE = Path("/tmp/.alembic_migration.stamp")
+
+
+def ensure_schema_is_up_to_date() -> None:
+    """Run Alembic migrations once per container start.
+
+    The function is safe to be called multiple times – it is idempotent thanks
+    to a combination of a file lock and a sentinel file.  If the migrations are
+    already applied we simply return immediately.  Otherwise we execute
+    ``alembic upgrade head`` to bring the database schema to the latest
+    revision.
+    """
+
+    # Make sure the parent directory exists so that we can create the lock.
+    _LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+    with _LOCK_FILE.open("w") as lock_fp:
+        fcntl.flock(lock_fp, fcntl.LOCK_EX)
+        try:
+            if _STAMP_FILE.exists():
+                logger.info("Database migrations already applied – skipping upgrade")
+                return
+
+            logger.info("Applying database migrations…")
+            alembic_cfg = Config("alembic.ini")
+            command.upgrade(alembic_cfg, "head")
+            _STAMP_FILE.write_text("applied")
+            logger.info("Database migrations successfully applied")
+        finally:
+            fcntl.flock(lock_fp, fcntl.LOCK_UN)


### PR DESCRIPTION
## Summary
- add a startup hook that triggers Alembic migrations so the schema is ready before serving requests
- implement a migration helper with a filesystem lock to avoid concurrent upgrades when multiple workers boot

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d395531764832a98daaa8048317793