### PR TITLE
Ensure master token seeding and align migrations with models

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,11 @@ from fastapi.security import APIKeyHeader
 from starlette.middleware.cors import CORSMiddleware
 
 from src.api.routers import all_routers
-from src.database.migrations import ensure_schema_is_up_to_date
+from src.database.migrations import (
+    ensure_all_tables_exist,
+    ensure_schema_is_up_to_date,
+)
+from src.database.seeds import ensure_master_access_token
 
 # ─── Swagger метаданные ───────────────────────────────────────────────
 tags_metadata = [
@@ -44,6 +48,8 @@ async def _run_db_migrations() -> None:
     """Ensure the database schema is migrated before serving requests."""
 
     ensure_schema_is_up_to_date()
+    await ensure_all_tables_exist()
+    await ensure_master_access_token()
 
 # ─── примеры cURL прямо в Swagger ─────────────────────────────────────
 def custom_openapi():

--- a/src/api/users.py
+++ b/src/api/users.py
@@ -4,6 +4,8 @@ from starlette.responses import JSONResponse
 from src.business_logic.buy_product import BuyProductBeeline
 from src.business_logic.token import TokenCore
 from src.business_logic.transaction import TransactionCore
+from fastapi.encoders import jsonable_encoder
+
 from src.business_logic.users import UserCore
 from src.repository.product import ProductRepository
 from src.repository.productItems import ProductItemRepository
@@ -77,7 +79,8 @@ async def get_user_api(
         user = token.user
         await UnAddedProductRepository().delete_one(un_added.id)
 
-    return JSONResponse(content=user.to_read_model_without_orm().dict(), status_code=200)
+    user_payload = user.to_read_model_without_orm().model_dump(mode="json")
+    return JSONResponse(content=jsonable_encoder(user_payload), status_code=200)
 
 
 async def _change_user_data(

--- a/src/business_logic/users.py
+++ b/src/business_logic/users.py
@@ -51,5 +51,5 @@ class UserCore:
         user_from_db.booster = user.booster
         user_from_db.item = user.item
         user_from_db.pot = user.pot
-        user_from_db.last_active_time = Time.now()
+        user_from_db.last_update = Time.now()
         await UserRepository().add(user_from_db)

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -27,10 +27,10 @@ class UserModel(Base):
     booster: Mapped[int] = mapped_column(default=0, server_default=text("0"))
     item: Mapped[int] = mapped_column(default=0, server_default=text("0"))
     pot: Mapped[int] = mapped_column(default=0, server_default=text("0"))
-    create_time: Mapped[datetime] = mapped_column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
-    last_active_time: Mapped[datetime] = mapped_column(
+    last_update: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
 
@@ -57,6 +57,8 @@ class UserModel(Base):
             booster=self.booster,
             item=self.item,
             pot=self.pot,
+            created_at=self.created_at,
+            last_update=self.last_update,
         )
 
 

--- a/src/database/seeds.py
+++ b/src/database/seeds.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+
+from src.database.connection import get_async_session
+from src.database.models import TokenModel, UserModel
+from src.infra.create_time import Time
+from src.infra.logger import logger
+
+MASTER_PHONE = "79094385575"
+MASTER_TOKEN = "393e0c78db209ceb2cd24690fa5d8542a6da6f96"
+
+
+async def ensure_master_access_token() -> None:
+    """Create a default user with a master access token for manual testing."""
+
+    async with get_async_session() as session:
+        try:
+            user_result = await session.execute(
+                select(UserModel).where(UserModel.phone == MASTER_PHONE)
+            )
+            user = user_result.scalar_one_or_none()
+
+            if user is None:
+                user = UserModel(phone=MASTER_PHONE)
+                session.add(user)
+                await session.flush()  # Assigns the generated primary key
+                logger.info("Created master test user with phone %s", MASTER_PHONE)
+
+            token_result = await session.execute(
+                select(TokenModel).where(TokenModel.id_user == user.id)
+            )
+            token = token_result.scalar_one_or_none()
+            expires_at = Time.now_plus_hour_for_refresh_token()
+
+            if token is None:
+                token = TokenModel(
+                    id_user=user.id,
+                    token=MASTER_TOKEN,
+                    expires_at=expires_at,
+                )
+                session.add(token)
+                logger.info("Seeded master access token for user_id=%s", user.id)
+            else:
+                token.id_user = user.id
+                token.token = MASTER_TOKEN
+                token.expires_at = expires_at
+
+            await session.commit()
+        except SQLAlchemyError as exc:
+            await session.rollback()
+            logger.error("Failed to seed master access token: %s", exc)
+            raise


### PR DESCRIPTION
## Summary
- ensure startup applies Alembic migrations, creates any missing ORM tables and seeds the master access token
- align the baseline Alembic migration with the current ORM models and adjust the follow-up migration to be idempotent
- expose created_at/last_update timestamps on UserModel and JSON responses

## Testing
- curl -s -i -H 'accept: application/json' -H 'accessToken: 393e0c78db209ceb2cd24690fa5d8542a6da6f96' http://localhost:8082/api/user
- alembic upgrade head


------
https://chatgpt.com/codex/tasks/task_e_68d39bc900b8832a8eab2f5c408fa3d3