### PR TITLE
Ensure migrations run when database is reset

### DIFF
--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -8,12 +8,13 @@ from pathlib import Path
 from alembic import command
 from alembic.config import Config
 from alembic.script import ScriptDirectory
-from sqlalchemy import inspect
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import SQLAlchemyError
 
 from sqlalchemy.ext.asyncio import AsyncConnection
 
-from src.database.connection import Base, engine
+from src.database.connection import Base, DATABASE_URL, engine
 from src.database.models import TokenModel
 
 from src.infra.logger import logger
@@ -26,6 +27,29 @@ _LOCK_FILE = Path("/tmp/.alembic_migration.lock")
 # The stamp file contains the latest Alembic revision that was applied.  We
 # compare it with the current head to decide whether an upgrade is required.
 _STAMP_FILE = Path("/tmp/.alembic_migration.stamp")
+
+# Alembic needs a synchronous connection to introspect the currently applied
+# revision.  The application itself talks to the database via ``asyncpg`` but
+# for migration bookkeeping we open a lightweight synchronous engine using the
+# same credentials.
+_SYNC_DATABASE_URL = make_url(DATABASE_URL)
+if "+asyncpg" in _SYNC_DATABASE_URL.drivername:
+    _SYNC_DATABASE_URL = _SYNC_DATABASE_URL.set(
+        drivername=_SYNC_DATABASE_URL.drivername.replace("+asyncpg", "+psycopg2")
+    )
+_SYNC_ENGINE = create_engine(_SYNC_DATABASE_URL)
+
+
+def _get_current_database_revision() -> str | None:
+    """Return the revision stored in the database or ``None`` if missing."""
+
+    with _SYNC_ENGINE.connect() as connection:
+        inspector = inspect(connection)
+        if "alembic_version" not in inspector.get_table_names():
+            return None
+
+        result = connection.execute(text("SELECT version_num FROM alembic_version"))
+        return result.scalar()
 
 
 def ensure_schema_is_up_to_date() -> None:
@@ -52,22 +76,34 @@ def ensure_schema_is_up_to_date() -> None:
             if _STAMP_FILE.exists():
                 stamped_revision = _STAMP_FILE.read_text().strip() or None
 
-            if stamped_revision == current_head:
+            database_revision = _get_current_database_revision()
+
+            if database_revision == current_head:
+                if stamped_revision != current_head:
+                    _STAMP_FILE.write_text(current_head)
                 logger.info(
                     "Database schema already at head revision %s – skipping upgrade",
                     current_head,
                 )
                 return
 
-            if stamped_revision is None:
+            if stamped_revision == current_head and database_revision != current_head:
+                logger.warning(
+                    "Stamp file recorded head revision %s but database is at %s – forcing upgrade",
+                    stamped_revision,
+                    database_revision or "<uninitialized>",
+                )
+
+            if stamped_revision is None and database_revision is None:
                 logger.info(
                     "Applying database migrations up to head revision %s…",
                     current_head,
                 )
             else:
+                previous_revision = database_revision or stamped_revision
                 logger.info(
                     "New migrations detected (%s → %s); applying upgrade…",
-                    stamped_revision,
+                    previous_revision,
                     current_head,
                 )
 


### PR DESCRIPTION
## Summary
- ensure Alembic migrations verify the database revision before skipping upgrades
- add a synchronous engine helper so the migration lock can detect reset databases and refresh the stamp file

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3aa8d21e8832ab8685a73a5d95c2c