### PR TITLE
Add roulette API to OpenAPI docs

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ tags_metadata = [
     {"name": "Auth",    "description": "Авторизация и платежи"},
     {"name": "User",    "description": "Профиль игрока и ресурсы"},
     {"name": "Product", "description": "Каталог магазинов"},
+    {"name": "Roulette","description": "Персональные рулетки"},
     {"name": "Events",  "description": "Соревнования и лидерборды"},
     {"name": "Prizes",  "description": "Незабранные награды"},
 ]

--- a/src/api/routers.py
+++ b/src/api/routers.py
@@ -12,6 +12,7 @@ all_routers = [
     user_router,
     product_router,
     auth_router,
+    roulette_router,
     events_router,
     prizes_router,
     system_router,


### PR DESCRIPTION
## Summary
- register the roulette router so its endpoints appear in the documentation
- add the Roulette tag metadata to describe the section in Swagger

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d500197f48832aa6db27cb07dd2f71