### PR TITLE
Convert booster, item, and pot fields to strings

### DIFF
--- a/migration/versions/3a93f942f3bd_change_booster_item_pot_to_string.py
+++ b/migration/versions/3a93f942f3bd_change_booster_item_pot_to_string.py
@@ -1,0 +1,47 @@
+"""Change booster, item and pot columns to string.
+
+Revision ID: 3a93f942f3bd
+Revises: 84f9db1dfc1b
+Create Date: 2025-09-25
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "3a93f942f3bd"
+down_revision = "84f9db1dfc1b"
+branch_labels = None
+depends_on = None
+
+
+_TARGET_TABLES = ("users", "products_item")
+_TARGET_COLUMNS = ("booster", "item", "pot")
+
+
+def upgrade() -> None:
+    for table in _TARGET_TABLES:
+        for column in _TARGET_COLUMNS:
+            op.alter_column(
+                table,
+                column,
+                type_=sa.String(),
+                existing_type=sa.Integer(),
+                existing_server_default=sa.text("0"),
+                server_default=sa.text("''"),
+                postgresql_using=f"{column}::text",
+            )
+
+
+def downgrade() -> None:
+    for table in _TARGET_TABLES:
+        for column in _TARGET_COLUMNS:
+            op.alter_column(
+                table,
+                column,
+                type_=sa.Integer(),
+                existing_type=sa.String(),
+                existing_server_default=sa.text("''"),
+                server_default=sa.text("0"),
+                postgresql_using=f"NULLIF({column}, '')::integer",
+            )

--- a/src/api/users.py
+++ b/src/api/users.py
@@ -32,11 +32,11 @@ async def add_item_product(user, items_product) -> UserSchemaForChange:
     if items_product.level:
         user.level += items_product.level
     if items_product.booster:
-        user.booster += items_product.booster
+        user.booster = items_product.booster
     if items_product.item:
-        user.item += items_product.item
+        user.item = items_product.item
     if items_product.pot:
-        user.pot += items_product.pot
+        user.pot = items_product.pot
 
     return UserSchemaForChange(
         coins=user.coins,

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -24,9 +24,9 @@ class UserModel(Base):
     rare_seed: Mapped[int] = mapped_column(default=0, server_default=text("0"))
     water: Mapped[int] = mapped_column(default=0, server_default=text("0"))
     level: Mapped[int] = mapped_column(default=1, server_default=text("1"))
-    booster: Mapped[int] = mapped_column(default=0, server_default=text("0"))
-    item: Mapped[int] = mapped_column(default=0, server_default=text("0"))
-    pot: Mapped[int] = mapped_column(default=0, server_default=text("0"))
+    booster: Mapped[str] = mapped_column(default="", server_default=text("''"))
+    item: Mapped[str] = mapped_column(default="", server_default=text("''"))
+    pot: Mapped[str] = mapped_column(default="", server_default=text("''"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
@@ -90,9 +90,9 @@ class ProductItemModel(Base):
     rare_seed: Mapped[int] = mapped_column(default=0, server_default=text("0"))
     water: Mapped[int] = mapped_column(default=0, server_default=text("0"))
     level: Mapped[int] = mapped_column(default=0, server_default=text("0"))
-    booster: Mapped[int] = mapped_column(default=0, server_default=text("0"))
-    item: Mapped[int] = mapped_column(default=0, server_default=text("0"))
-    pot: Mapped[int] = mapped_column(default=0, server_default=text("0"))
+    booster: Mapped[str] = mapped_column(default="", server_default=text("''"))
+    item: Mapped[str] = mapped_column(default="", server_default=text("''"))
+    pot: Mapped[str] = mapped_column(default="", server_default=text("''"))
 
     products: Mapped[list["ProductModel"]] = relationship(
         "ProductModel", back_populates="item"

--- a/src/schemas/users.py
+++ b/src/schemas/users.py
@@ -18,9 +18,9 @@ class UserSchema(BaseModel):
     rare_seed: int
     water: int
     level: int
-    booster: int
-    item: int
-    pot: int
+    booster: str
+    item: str
+    pot: str
 
     created_at: datetime
     last_update: datetime
@@ -40,9 +40,9 @@ class UserSchemaForChange(BaseModel):
     rare_seed: int
     water: int
     level: int
-    booster: int
-    item: int
-    pot: int
+    booster: str
+    item: str
+    pot: str
 
     model_config = {"from_attributes": True}
 
@@ -59,9 +59,9 @@ class UserSchemaWithoutOrm(BaseModel):
     rare_seed: int
     water: int
     level: int
-    booster: int
-    item: int
-    pot: int
+    booster: str
+    item: str
+    pot: str
 
     created_at: datetime
     last_update: datetime


### PR DESCRIPTION
## Summary
- update user and product item models so booster, item, and pot are stored as strings by default
- adjust API and Pydantic schemas to treat booster, item, and pot values as strings
- add an Alembic migration converting the affected columns in `users` and `products_item`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d65c2ab2e8832a8af109c30192ac54